### PR TITLE
Fix variable name mismatch between conf. and env files

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -54,7 +54,7 @@ return [
 
         'mysql' => [
             'driver'    => 'mysql',
-            'host'      => env('MYSQL_HOSTNAME', 'localhost'),
+            'host'      => env('MYSQL_HOST', 'localhost'),
             'database'  => env('MYSQL_DATABASE', 'forge'),
             'username'  => env('MYSQL_USER', 'forge'),
             'password'  => env('MYSQL_PASSWORD', ''),


### PR DESCRIPTION
Variable name mismatch between configuration file and .env file, causes application to ignore the `MYSQL_HOST` parameter and fallback to `localhost`.

